### PR TITLE
Switch to docker image and manifest updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "helipad"]
-	path = helipad
-	url = https://github.com/Podcastindex-org/helipad

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,16 @@
-##: Build stage
-FROM rust:latest AS builder
-
-# arm64 or amd64
-ARG PLATFORM
-
-USER root
-
-RUN apt-get update
-RUN apt-get install -y apt-utils sqlite3 openssl
-
-COPY helipad /opt/helipad
-
-WORKDIR /opt/helipad
-RUN cargo build --release
-RUN cp target/release/helipad .
-
-##: Bundle stage
-FROM debian:buster-slim AS runner
+# sha256 from: docker buildx imagetools inspect <image>
+FROM podcastindexorg/podcasting20-helipad@sha256:6767de3126b0a7d317f7c87766a1f063baa44fb85dc5496c794ff9aff306a4c1
 
 ARG ARCH
 ARG PLATFORM
 
 USER root
 
-RUN apt-get update && apt-get install -y apt-utils ca-certificates openssl sqlite3 tini
+RUN apt-get update && \
+    apt-get install -y tini && \
+    rm -fr /var/lib/apt/lists/*
 
 COPY ./docker_entrypoint.sh /usr/local/bin/docker_entrypoint.sh
 RUN chmod +x /usr/local/bin/*.sh
-
-RUN mkdir /opt/helipad
-
-WORKDIR /opt/helipad
-COPY --from=builder /opt/helipad/target/release/helipad .
-COPY --from=builder /opt/helipad/webroot ./webroot
-COPY --from=builder /opt/helipad/helipad.conf .
-
-RUN useradd -u 1000 helipad
-
-EXPOSE 2112/tcp
 
 ENTRYPOINT ["/usr/local/bin/docker_entrypoint.sh"]

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -4,7 +4,7 @@ version: 0.1.10.5
 release-notes: |
   * v0.1.10 - Elements of style... (v0.1.10) [Release Notes](https://github.com/Podcastindex-org/helipad/releases/tag/v0.1.10)
 license: mit
-wrapper-repo: "https://github.com/ericpp/helipad-startos"
+wrapper-repo: "https://github.com/Podcastindex-org/helipad-startos"
 upstream-repo: "https://github.com/Podcastindex-org/helipad"
 support-site: "https://podcastindex.social"
 marketing-site: "https://podcastindex.org"

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 id: helipad 
 title: "Helipad"
-version: 0.1.10
+version: 0.1.10.5
 release-notes: |
   * v0.1.10 - Elements of style... (v0.1.10) [Release Notes](https://github.com/Podcastindex-org/helipad/releases/tag/v0.1.10)
 license: mit

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -31,11 +31,7 @@ health-checks:
     name: Web Interface
     success-message: Helipad is ready to visit in a web browser
     type: script
-config: 
-  get:
-    type: script
-  set:
-    type: script
+config: ~
 properties:
   type: script
 volumes:

--- a/scripts/embassy.ts
+++ b/scripts/embassy.ts
@@ -1,5 +1,3 @@
-export { setConfig } from "./services/setConfig.ts";
 export { properties } from "./services/properties.ts";
-export { getConfig } from "./services/getConfig.ts";
 export { health } from "./services/healthChecks.ts";
 export { migration } from "./services/migrations.ts";

--- a/scripts/embassy.ts
+++ b/scripts/embassy.ts
@@ -2,3 +2,4 @@ export { setConfig } from "./services/setConfig.ts";
 export { properties } from "./services/properties.ts";
 export { getConfig } from "./services/getConfig.ts";
 export { health } from "./services/healthChecks.ts";
+export { migration } from "./services/migrations.ts";

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -1,5 +1,0 @@
-// To utilize the default config system built, this file is required. It defines the *structure* of the configuration file. These structured options display as changeable UI elements within the "Config" section of the service details page in the Embassy UI.
-
-import { compat, types as T } from "../deps.ts";
-
-export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({});

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -1,0 +1,5 @@
+import { compat, types as T } from "../deps.ts";
+
+export const migration: T.ExpectedExports.migration =
+  compat.migrations.fromMapping({}, "0.1.10.4");
+

--- a/scripts/services/setConfig.ts
+++ b/scripts/services/setConfig.ts
@@ -1,3 +1,0 @@
-import { compat, } from "../deps.ts";
-
-export const setConfig = compat.setConfig;


### PR DESCRIPTION
* Pinned the latest helipad docker image
* Updated manifest to: not require user config, handle version migrations, and point to the podcastindex-org startos repo